### PR TITLE
Fix RecursionError

### DIFF
--- a/ssm.py
+++ b/ssm.py
@@ -30,7 +30,7 @@ class SSM(Resolver):
         decoded_value = None
         if self.argument:
             param = self.argument
-            connection_manager = self.stack.template.connection_manager
+            connection_manager = self.stack.connection_manager
             try:
                 response = connection_manager.call(
                     service="ssm",


### PR DESCRIPTION
This fixes the Sceptre RecusionError[1] when attempting to
get the connection manager from the template object.  The
suggestion is to get it from the stack instead.

[1] https://github.com/cloudreach/sceptre/issues/558